### PR TITLE
Feature/inversion handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,6 @@ find_package(catkin_simple REQUIRED)
 catkin_simple(ALL_DEPS_REQUIRED)
 
 find_package(Eigen REQUIRED)
-
 include_directories(${Eigen_INCLUDE_DIRS})
 
 cs_add_library(vicon_estimator

--- a/include/vicon_estimator.h
+++ b/include/vicon_estimator.h
@@ -39,6 +39,7 @@ class TranslationalEstimatorParameters
 {
 
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   // Constructor
   TranslationalEstimatorParameters()
       : dt_(kDefaultDt),
@@ -134,6 +135,7 @@ class RotationalEstimatorParameters
 {
 
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   // Constructor
   RotationalEstimatorParameters()
       : dt_(kDefaultDt),
@@ -177,7 +179,13 @@ class RotationalEstimatorResults
         orientation_old_(Eigen::Quaterniond::Identity()),
         rate_old_(Eigen::Vector3d::Zero()),
         orientation_estimate_(Eigen::Quaterniond::Identity()),
-        rate_estimate_(Eigen::Vector3d::Zero())
+        rate_estimate_(Eigen::Vector3d::Zero()),
+        measurement_outlier_flag_(false),
+        measurement_flip_flag_(false),
+        q_Z_Z1_(Eigen::Quaterniond::Identity()),
+        q_Z_Z1_magnitude_(0.0),
+        q_Z_B_(Eigen::Quaterniond::Identity()),
+        q_Z_B_magnitude_(0.0)
   {
   }
   ;

--- a/include/vicon_estimator.h
+++ b/include/vicon_estimator.h
@@ -183,9 +183,7 @@ class RotationalEstimatorResults
         measurement_outlier_flag_(false),
         measurement_flip_flag_(false),
         q_Z_Z1_(Eigen::Quaterniond::Identity()),
-        q_Z_Z1_magnitude_(0.0),
-        q_Z_B_(Eigen::Quaterniond::Identity()),
-        q_Z_B_magnitude_(0.0)
+        q_Z_B_(Eigen::Quaterniond::Identity())
   {
   }
   ;
@@ -199,9 +197,7 @@ class RotationalEstimatorResults
   bool measurement_outlier_flag_;
   bool measurement_flip_flag_;
   Eigen::Quaterniond q_Z_Z1_;
-  double q_Z_Z1_magnitude_;
   Eigen::Quaterniond q_Z_B_;
-  double q_Z_B_magnitude_;
 
 };
 

--- a/include/vicon_estimator.h
+++ b/include/vicon_estimator.h
@@ -22,10 +22,6 @@
 #ifndef VICON_ESTIMATOR_H
 #define VICON_ESTIMATOR_H
 
-#include <iostream>
-#include <stdio.h>
-#include <math.h>
-
 #include <Eigen/Geometry>
 
 namespace vicon_estimator {
@@ -67,7 +63,7 @@ class TranslationalEstimatorResults
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   // Constructor
   TranslationalEstimatorResults()
-      : position_measured(Eigen::Vector3d::Zero()),
+      : position_measured_(Eigen::Vector3d::Zero()),
         position_old_(Eigen::Vector3d::Zero()),
         velocity_old_(Eigen::Vector3d::Zero()),
         position_estimate_(Eigen::Vector3d::Zero()),
@@ -76,7 +72,7 @@ class TranslationalEstimatorResults
   }
 
   // Intermediate Estimator results
-  Eigen::Vector3d position_measured;
+  Eigen::Vector3d position_measured_;
   Eigen::Vector3d position_old_;
   Eigen::Vector3d velocity_old_;
   Eigen::Vector3d position_estimate_;
@@ -188,10 +184,17 @@ class RotationalEstimatorResults
 
   // Intermediate Estimator results
   Eigen::Quaterniond orientation_measured_;
+  Eigen::Quaterniond orientation_measured_corrected_;
   Eigen::Quaterniond orientation_old_;
   Eigen::Vector3d rate_old_;
   Eigen::Quaterniond orientation_estimate_;
   Eigen::Vector3d rate_estimate_;
+  bool measurement_outlier_flag_;
+  bool measurement_flip_flag_;
+  Eigen::Quaterniond q_Z_Z1_;
+  double q_Z_Z1_magnitude_;
+  Eigen::Quaterniond q_Z_B_;
+  double q_Z_B_magnitude_;
 
 };
 
@@ -272,6 +275,14 @@ class RotationalEstimator
   bool detectMeasurementOutlier(const Eigen::Quaterniond& orientation_measured);
   // Returns the magnitude of the rotation represented by a quaternion
   double quaternionRotationMagnitude(const Eigen::Quaterniond& rotation);
+
+  // Corrects for the redundancy in measured quaternions
+  void correctRedundantMeasurement(const Eigen::Quaterniond& orientation_measured,
+                                   const Eigen::Matrix<double, 7, 1>& x_priori,
+                                   Eigen::Quaterniond* corrected_orientation_measured);
+
+  void correctPosterioriState(const Eigen::Matrix<double, 7, 1>& x_m,
+                              Eigen::Matrix<double, 7, 1>* x_m_corrected);
 
 };
 

--- a/include/vicon_estimator.h
+++ b/include/vicon_estimator.h
@@ -130,6 +130,7 @@ static const Eigen::Vector3d kDefaultInitialDorientationEstimate = Eigen::Vector
 static const Eigen::Vector3d kDefaultInitialDrateEstimate = Eigen::Vector3d::Zero();
 static const double kDefaultOutlierThresholdDegrees = 30.0;
 static const int kDefaultMaximumOutlierCount = 10;
+static const bool kOutputMinimalQuaternions = false;
 
 class RotationalEstimatorParameters
 {
@@ -149,7 +150,8 @@ class RotationalEstimatorParameters
         initial_dorientation_estimate_(kDefaultInitialDorientationEstimate),
         initial_drate_estimate_(kDefaultInitialDrateEstimate),
         outlier_threshold_degrees_(kDefaultOutlierThresholdDegrees),
-        maximum_outlier_count_(kDefaultMaximumOutlierCount)
+        maximum_outlier_count_(kDefaultMaximumOutlierCount),
+        output_minimal_quaternions_(kOutputMinimalQuaternions)
   {
   }
   ;
@@ -166,6 +168,7 @@ class RotationalEstimatorParameters
   Eigen::Vector3d initial_drate_estimate_;
   double outlier_threshold_degrees_;
   int maximum_outlier_count_;
+  bool output_minimal_quaternions_;
 };
 
 class RotationalEstimatorResults
@@ -219,12 +222,9 @@ class RotationalEstimator
   // Return intermediate results structure
   RotationalEstimatorResults getResults() const { return estimator_results_; }
   // Return estimated orientation
-  const Eigen::Quaterniond getEstimatedOrientation() const { return orientation_estimate_B_W_; }
+  Eigen::Quaterniond getEstimatedOrientation() const;
   // Return estimated angular velocity
-  Eigen::Vector3d getEstimatedRate() const
-  {
-    return rate_estimate_B_;
-  }
+  Eigen::Vector3d getEstimatedRate() const;
 
  private:
 

--- a/include/vicon_estimator.h
+++ b/include/vicon_estimator.h
@@ -184,7 +184,6 @@ class RotationalEstimatorResults
 
   // Intermediate Estimator results
   Eigen::Quaterniond orientation_measured_;
-  Eigen::Quaterniond orientation_measured_corrected_;
   Eigen::Quaterniond orientation_old_;
   Eigen::Vector3d rate_old_;
   Eigen::Quaterniond orientation_estimate_;

--- a/include/vicon_estimator.h
+++ b/include/vicon_estimator.h
@@ -276,14 +276,6 @@ class RotationalEstimator
   // Returns the magnitude of the rotation represented by a quaternion
   double quaternionRotationMagnitude(const Eigen::Quaterniond& rotation);
 
-  // Corrects for the redundancy in measured quaternions
-  void correctRedundantMeasurement(const Eigen::Quaterniond& orientation_measured,
-                                   const Eigen::Matrix<double, 7, 1>& x_priori,
-                                   Eigen::Quaterniond* corrected_orientation_measured);
-
-  void correctPosterioriState(const Eigen::Matrix<double, 7, 1>& x_m,
-                              Eigen::Matrix<double, 7, 1>* x_m_corrected);
-
 };
 
 class ViconEstimator

--- a/launch/asl_vicon.launch
+++ b/launch/asl_vicon.launch
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="object_name" default="auk" />
+  <arg name="object_name" default="bluebird" />
   <node ns="$(arg object_name)" name="vrpn_client" type="ros_vrpn_client" pkg="ros_vrpn_client" output="screen">
     <param name="vrpn_server_ip" value="vicon" />
     <param name="vrpn_coordinate_system" value="vicon" />

--- a/launch/asl_vicon.launch
+++ b/launch/asl_vicon.launch
@@ -9,9 +9,9 @@
     <param name="translational_estimator/kv" value="0.1" />
     <param name="rotational_estimator/orientation_estimate_initial_covariance" value="1" />
     <param name="rotational_estimator/rate_estimate_initial_covariance" value="1" />
-    <param name="rotational_estimator/orientation_process_covariance" value="0.001" />
-    <param name="rotational_estimator/rate_process_covariance" value="1" />
-    <param name="rotational_estimator/orientation_measurementCovariance" value="0.0005" />
+    <param name="rotational_estimator/orientation_process_covariance" value="0.00001" />
+    <param name="rotational_estimator/rate_process_covariance" value="10" />
+    <param name="rotational_estimator/orientation_measurementCovariance" value="0.005" />
     <param name="rotational_estimator/outlier_threshold_degrees" value="10" />
     <param name="rotational_estimator/maximum_outlier_count" value="50" />    
   </node>

--- a/launch/asl_vicon.launch
+++ b/launch/asl_vicon.launch
@@ -12,7 +12,7 @@
     <param name="rotational_estimator/orientation_process_covariance" value="0.00001" />
     <param name="rotational_estimator/rate_process_covariance" value="10" />
     <param name="rotational_estimator/orientation_measurementCovariance" value="0.005" />
-    <param name="rotational_estimator/outlier_threshold_degrees" value="10" />
+    <param name="rotational_estimator/outlier_threshold_degrees" value="30" />
     <param name="rotational_estimator/maximum_outlier_count" value="50" />    
     <param name="rotational_estimator/output_minimal_quaternions" value="false" />
   </node>

--- a/launch/asl_vicon.launch
+++ b/launch/asl_vicon.launch
@@ -5,7 +5,7 @@
     <param name="vrpn_coordinate_system" value="vicon" />
     <param name="object_name" value="$(arg object_name)" />
     <param name="vicon_estimator/dt" value="0.01" />
-    <param name="translational_estimator/kp" value="0.1" />
+    <param name="translational_estimator/kp" value="1.0" />
     <param name="translational_estimator/kv" value="0.1" />
     <param name="rotational_estimator/orientation_estimate_initial_covariance" value="1" />
     <param name="rotational_estimator/rate_estimate_initial_covariance" value="1" />
@@ -14,5 +14,6 @@
     <param name="rotational_estimator/orientation_measurementCovariance" value="0.005" />
     <param name="rotational_estimator/outlier_threshold_degrees" value="10" />
     <param name="rotational_estimator/maximum_outlier_count" value="50" />    
+    <param name="rotational_estimator/output_minimal_quaternions" value="false" />
   </node>
 </launch>

--- a/launch/asl_vicon.launch
+++ b/launch/asl_vicon.launch
@@ -5,14 +5,14 @@
     <param name="vrpn_coordinate_system" value="vicon" />
     <param name="object_name" value="$(arg object_name)" />
     <param name="vicon_estimator/dt" value="0.01" />
-    <param name="translational_estimator/kp" value="1.0" />
-    <param name="translational_estimator/kv" value="10.0" />
+    <param name="translational_estimator/kp" value="0.1" />
+    <param name="translational_estimator/kv" value="0.1" />
     <param name="rotational_estimator/orientation_estimate_initial_covariance" value="1" />
     <param name="rotational_estimator/rate_estimate_initial_covariance" value="1" />
-    <param name="rotational_estimator/orientation_process_covariance" value="0.01" />
+    <param name="rotational_estimator/orientation_process_covariance" value="0.001" />
     <param name="rotational_estimator/rate_process_covariance" value="1" />
     <param name="rotational_estimator/orientation_measurementCovariance" value="0.0005" />
-    <param name="rotational_estimator/outlier_threshold_degrees" value="30" />
-    <param name="rotational_estimator/maximum_outlier_count" value="10" />    
+    <param name="rotational_estimator/outlier_threshold_degrees" value="10" />
+    <param name="rotational_estimator/maximum_outlier_count" value="50" />    
   </node>
 </launch>

--- a/launch/bagfile_vicon.launch
+++ b/launch/bagfile_vicon.launch
@@ -10,7 +10,7 @@
     <param name="rotational_estimator/orientation_process_covariance" value="0.00001" />
     <param name="rotational_estimator/rate_process_covariance" value="10" />
     <param name="rotational_estimator/orientation_measurementCovariance" value="0.005" />
-    <param name="rotational_estimator/outlier_threshold_degrees" value="10" />
+    <param name="rotational_estimator/outlier_threshold_degrees" value="30" />
     <param name="rotational_estimator/maximum_outlier_count" value="50" />
     <param name="rotational_estimator/output_minimal_quaternions" value="false" />
   </node>

--- a/launch/bagfile_vicon.launch
+++ b/launch/bagfile_vicon.launch
@@ -3,14 +3,14 @@
   <node ns="$(arg object_name)" name="vicon_estimator" type="vicon_estimation_node" pkg="ros_vrpn_client" output="screen">
     <param name="object_name" value="$(arg object_name)" />
     <param name="vicon_estimator/dt" value="0.01" />
-    <param name="translational_estimator/kp" value="0.01" />
+    <param name="translational_estimator/kp" value="0.1" />
     <param name="translational_estimator/kv" value="0.1" />
     <param name="rotational_estimator/orientation_estimate_initial_covariance" value="1" />
     <param name="rotational_estimator/rate_estimate_initial_covariance" value="1" />
-    <param name="rotational_estimator/orientation_process_covariance" value="0.01" />
+    <param name="rotational_estimator/orientation_process_covariance" value="0.001" />
     <param name="rotational_estimator/rate_process_covariance" value="1" />
     <param name="rotational_estimator/orientation_measurementCovariance" value="0.0005" />
-    <param name="rotational_estimator/outlier_threshold_degrees" value="30" />
-    <param name="rotational_estimator/maximum_outlier_count" value="10" />    
+    <param name="rotational_estimator/outlier_threshold_degrees" value="10" />
+    <param name="rotational_estimator/maximum_outlier_count" value="50" />    
   </node>
 </launch>

--- a/launch/bagfile_vicon.launch
+++ b/launch/bagfile_vicon.launch
@@ -7,9 +7,9 @@
     <param name="translational_estimator/kv" value="0.1" />
     <param name="rotational_estimator/orientation_estimate_initial_covariance" value="1" />
     <param name="rotational_estimator/rate_estimate_initial_covariance" value="1" />
-    <param name="rotational_estimator/orientation_process_covariance" value="0.001" />
-    <param name="rotational_estimator/rate_process_covariance" value="1" />
-    <param name="rotational_estimator/orientation_measurementCovariance" value="0.0005" />
+    <param name="rotational_estimator/orientation_process_covariance" value="0.00001" />
+    <param name="rotational_estimator/rate_process_covariance" value="10" />
+    <param name="rotational_estimator/orientation_measurementCovariance" value="0.005" />
     <param name="rotational_estimator/outlier_threshold_degrees" value="10" />
     <param name="rotational_estimator/maximum_outlier_count" value="50" />    
   </node>

--- a/launch/bagfile_vicon.launch
+++ b/launch/bagfile_vicon.launch
@@ -3,7 +3,7 @@
   <node ns="$(arg object_name)" name="vicon_estimator" type="vicon_estimation_node" pkg="ros_vrpn_client" output="screen">
     <param name="object_name" value="$(arg object_name)" />
     <param name="vicon_estimator/dt" value="0.01" />
-    <param name="translational_estimator/kp" value="0.1" />
+    <param name="translational_estimator/kp" value="1.0" />
     <param name="translational_estimator/kv" value="0.1" />
     <param name="rotational_estimator/orientation_estimate_initial_covariance" value="1" />
     <param name="rotational_estimator/rate_estimate_initial_covariance" value="1" />
@@ -11,6 +11,7 @@
     <param name="rotational_estimator/rate_process_covariance" value="10" />
     <param name="rotational_estimator/orientation_measurementCovariance" value="0.005" />
     <param name="rotational_estimator/outlier_threshold_degrees" value="10" />
-    <param name="rotational_estimator/maximum_outlier_count" value="50" />    
+    <param name="rotational_estimator/maximum_outlier_count" value="50" />
+    <param name="rotational_estimator/output_minimal_quaternions" value="false" />
   </node>
 </launch>

--- a/launch/bagfile_vicon.launch
+++ b/launch/bagfile_vicon.launch
@@ -3,8 +3,8 @@
   <node ns="$(arg object_name)" name="vicon_estimator" type="vicon_estimation_node" pkg="ros_vrpn_client" output="screen">
     <param name="object_name" value="$(arg object_name)" />
     <param name="vicon_estimator/dt" value="0.01" />
-    <param name="translational_estimator/kp" value="1.0" />
-    <param name="translational_estimator/kv" value="10.0" />
+    <param name="translational_estimator/kp" value="0.01" />
+    <param name="translational_estimator/kv" value="0.1" />
     <param name="rotational_estimator/orientation_estimate_initial_covariance" value="1" />
     <param name="rotational_estimator/rate_estimate_initial_covariance" value="1" />
     <param name="rotational_estimator/orientation_process_covariance" value="0.01" />

--- a/msg/viconEstimator.msg
+++ b/msg/viconEstimator.msg
@@ -1,23 +1,22 @@
 Header header
 
-geometry_msgs/Vector3 		pos_measured 	# the measured body position
-geometry_msgs/Vector3 		pos_old 			# the old body position
-geometry_msgs/Vector3 		vel_old  			# the old body velocity
-geometry_msgs/Vector3 		pos_est				# the posteriori body position
-geometry_msgs/Vector3 		vel_est				# the posteriori body velocity
+geometry_msgs/Vector3     pos_measured           # the measured body position
+geometry_msgs/Vector3     pos_old                # the old body position
+geometry_msgs/Vector3     vel_old                # the old body velocity
+geometry_msgs/Vector3     pos_est                # the posteriori body position
+geometry_msgs/Vector3     vel_est                # the posteriori body velocity
 
-geometry_msgs/Quaternion 	quat_measured # the measured body orientation
-geometry_msgs/Quaternion  quat_measured_corrected # the measured body orientation
-geometry_msgs/Quaternion 	quat_old 			# the old body orientation
-geometry_msgs/Vector3 		omega_old  		# the old body rate
-geometry_msgs/Quaternion 	quat_est			# the posteriori body orientation
-geometry_msgs/Vector3 		omega_est			# the posteriori body rate
+geometry_msgs/Quaternion  quat_measured          # the measured body orientation
+geometry_msgs/Quaternion  quat_old               # the old body orientation
+geometry_msgs/Vector3     omega_old              # the old body rate
+geometry_msgs/Quaternion  quat_est               # the posteriori body orientation
+geometry_msgs/Vector3     omega_est              # the posteriori body rate
 
-std_msgs/Bool             outlier_flag  # Flag indicating if the measurement at this timestep was detected as being an outlier
-std_msgs/Bool             measurement_flip_flag  # Flag indicating if the measurement from vicon has undergone a redundant flipping.
+std_msgs/Bool             outlier_flag           # flag indicating if the measurement at this timestep was detected as being an outlier
+std_msgs/Bool             measurement_flip_flag  # flag indicating if the measurement from vicon has undergone a redundant flipping.
 
-geometry_msgs/Quaternion  q_Z_Z1        # the measurement to last measurement error quaternion
-std_msgs/Float64          q_Z_Z1_magnitude # The magnitude of the messurement error
+geometry_msgs/Quaternion  q_Z_Z1                 # the quaternion representing the rotation between subsequent measurements
+std_msgs/Float64          q_Z_Z1_magnitude       # the magnitude of the quaternion representing the rotation between subsequent measurements
 
-geometry_msgs/Quaternion  q_Z_B         # the measurement to body error quaternion
-std_msgs/Float64          q_Z_B_magnitude # The magnitude of the messurement error
+geometry_msgs/Quaternion  q_Z_B                  # the quaternion representing the rotation between measurement and body
+std_msgs/Float64          q_Z_B_magnitude        # the magnitude of the quaternion representing the rotation between measurement and body

--- a/msg/viconEstimator.msg
+++ b/msg/viconEstimator.msg
@@ -7,7 +7,17 @@ geometry_msgs/Vector3 		pos_est				# the posteriori body position
 geometry_msgs/Vector3 		vel_est				# the posteriori body velocity
 
 geometry_msgs/Quaternion 	quat_measured # the measured body orientation
+geometry_msgs/Quaternion  quat_measured_corrected # the measured body orientation
 geometry_msgs/Quaternion 	quat_old 			# the old body orientation
 geometry_msgs/Vector3 		omega_old  		# the old body rate
 geometry_msgs/Quaternion 	quat_est			# the posteriori body orientation
 geometry_msgs/Vector3 		omega_est			# the posteriori body rate
+
+std_msgs/Bool             outlier_flag  # Flag indicating if the measurement at this timestep was detected as being an outlier
+std_msgs/Bool             measurement_flip_flag  # Flag indicating if the measurement from vicon has undergone a redundant flipping.
+
+geometry_msgs/Quaternion  q_Z_Z1        # the measurement to last measurement error quaternion
+std_msgs/Float64          q_Z_Z1_magnitude # The magnitude of the messurement error
+
+geometry_msgs/Quaternion  q_Z_B         # the measurement to body error quaternion
+std_msgs/Float64          q_Z_B_magnitude # The magnitude of the messurement error

--- a/msg/viconEstimator.msg
+++ b/msg/viconEstimator.msg
@@ -16,7 +16,4 @@ std_msgs/Bool             outlier_flag           # flag indicating if the measur
 std_msgs/Bool             measurement_flip_flag  # flag indicating if the measurement from vicon has undergone a redundant flipping.
 
 geometry_msgs/Quaternion  q_Z_Z1                 # the quaternion representing the rotation between subsequent measurements
-std_msgs/Float64          q_Z_Z1_magnitude       # the magnitude of the quaternion representing the rotation between subsequent measurements
-
 geometry_msgs/Quaternion  q_Z_B                  # the quaternion representing the rotation between measurement and body
-std_msgs/Float64          q_Z_B_magnitude        # the magnitude of the quaternion representing the rotation between measurement and body

--- a/src/library/vicon_estimator.cpp
+++ b/src/library/vicon_estimator.cpp
@@ -460,6 +460,9 @@ bool RotationalEstimator::detectMeasurementOutlier(const Eigen::Quaterniond& ori
     measurement_outlier_flag = false;
   }
 
+  // Saving the flag to the intermediate results structure
+  estimator_results_.measurement_outlier_flag_ = measurement_outlier_flag;
+
   // If rotation too great indicate that measurement is corrupted
   if (measurement_outlier_flag) {
     ++outlier_counter_;

--- a/src/library/vicon_estimator.cpp
+++ b/src/library/vicon_estimator.cpp
@@ -175,6 +175,25 @@ void RotationalEstimator::setParameters(const RotationalEstimatorParameters& est
   estimator_parameters_ = estimator_parameters;
 }
 
+Eigen::Quaterniond RotationalEstimator::getEstimatedOrientation() const
+{
+  Eigen::Quaterniond orientation_for_return;
+  // Swapping to minimal (but redundant) representation if requested
+  if (estimator_parameters_.output_minimal_quaternions_) {
+    double correction_factor = orientation_estimate_B_W_.w() / std::abs(orientation_estimate_B_W_.w());
+    orientation_for_return = Eigen::Quaterniond(correction_factor * orientation_estimate_B_W_.coeffs());
+  } else {
+    orientation_for_return = orientation_estimate_B_W_;
+  }
+  return orientation_for_return;
+}
+
+Eigen::Vector3d RotationalEstimator::getEstimatedRate() const
+{
+  return rate_estimate_B_;
+}
+
+
 void RotationalEstimator::updateEstimate(const Eigen::Quaterniond& orientation_measured_B_W)
 {
   // Writing the raw measurement to the intermediate results structure

--- a/src/library/vicon_estimator.cpp
+++ b/src/library/vicon_estimator.cpp
@@ -446,9 +446,7 @@ bool RotationalEstimator::detectMeasurementOutlier(const Eigen::Quaterniond& ori
 
   // Writing the error quaternions and their magnitude to the intermediate results structure
   estimator_results_.q_Z_Z1_ = q_Z_Z1_;
-  estimator_results_.q_Z_Z1_magnitude_ = q_Z_Z1_magnitude_;
   estimator_results_.q_Z_B_ = q_Z_B_;
-  estimator_results_.q_Z_B_magnitude_ = q_Z_B_magnitude_;
 
   // Detecting if the measurement is an outlier
   bool measurement_outlier_flag = q_Z_Z1_magnitude_ 

--- a/src/vicon_estimation_node.cpp
+++ b/src/vicon_estimation_node.cpp
@@ -89,6 +89,8 @@ class ViconDataListener {
       // Publishing the estimates
       estimated_transform_pub_.publish(estimated_transform);
       estimated_odometry_pub_.publish(estimated_odometry);
+      // Publishing the estimator intermediate results
+      vicon_odometry_estimator_->publishIntermediateResults(msg->header.stamp);
     }
 
   private:

--- a/src/wrapper/vicon_odometry_estimator.cpp
+++ b/src/wrapper/vicon_odometry_estimator.cpp
@@ -90,28 +90,23 @@ void ViconOdometryEstimator::publishIntermediateResults(ros::Time timestamp)
 
   // Writing the measurement to the message object
   tf::vectorEigenToMsg(translational_estimator_results.position_measured_, msg.pos_measured);
-
   // Writing the old estimates to the message object
   tf::vectorEigenToMsg(translational_estimator_results.position_old_, msg.pos_old);
   tf::vectorEigenToMsg(translational_estimator_results.velocity_old_, msg.vel_old);
-
   // Posteriori results
   tf::vectorEigenToMsg(translational_estimator_results.position_estimate_, msg.pos_est);
   tf::vectorEigenToMsg(translational_estimator_results.velocity_estimate_, msg.vel_est);
 
   // Writing the measurement to the message object
   tf::quaternionEigenToMsg(rotational_estimator_results.orientation_measured_, msg.quat_measured);
-  tf::quaternionEigenToMsg(rotational_estimator_results.orientation_measured_corrected_, msg.quat_measured_corrected); 
-
   // Writing the old estimates to the message object
   tf::quaternionEigenToMsg(rotational_estimator_results.orientation_old_, msg.quat_old); 
   tf::vectorEigenToMsg(rotational_estimator_results.rate_old_, msg.omega_old);
-
   // Posteriori results
   tf::quaternionEigenToMsg(rotational_estimator_results.orientation_estimate_, msg.quat_est);
   tf::vectorEigenToMsg(rotational_estimator_results.rate_estimate_, msg.omega_est);
 
-  // Data to do with the measurement error
+  // Data to do with the orientation measurement outlier detection
   msg.outlier_flag.data = rotational_estimator_results.measurement_outlier_flag_;
   msg.measurement_flip_flag.data = rotational_estimator_results.measurement_flip_flag_;
   tf::quaternionEigenToMsg(rotational_estimator_results.q_Z_Z1_, msg.q_Z_Z1);

--- a/src/wrapper/vicon_odometry_estimator.cpp
+++ b/src/wrapper/vicon_odometry_estimator.cpp
@@ -110,9 +110,7 @@ void ViconOdometryEstimator::publishIntermediateResults(ros::Time timestamp)
   msg.outlier_flag.data = rotational_estimator_results.measurement_outlier_flag_;
   msg.measurement_flip_flag.data = rotational_estimator_results.measurement_flip_flag_;
   tf::quaternionEigenToMsg(rotational_estimator_results.q_Z_Z1_, msg.q_Z_Z1);
-  msg.q_Z_Z1_magnitude.data = rotational_estimator_results.q_Z_Z1_magnitude_; 
   tf::quaternionEigenToMsg(rotational_estimator_results.q_Z_B_, msg.q_Z_B);
-  msg.q_Z_B_magnitude.data = rotational_estimator_results.q_Z_B_magnitude_;   
 
   // Publishing estimator message
   publisher_.publish(msg);

--- a/src/wrapper/vicon_odometry_estimator.cpp
+++ b/src/wrapper/vicon_odometry_estimator.cpp
@@ -19,6 +19,8 @@
  * limitations under the License.
  */
 
+#include <eigen_conversions/eigen_msg.h>
+
 #include "vicon_odometry_estimator.h"
 
 namespace vicon_estimator {
@@ -87,45 +89,35 @@ void ViconOdometryEstimator::publishIntermediateResults(ros::Time timestamp)
   msg.header.stamp = timestamp;
 
   // Writing the measurement to the message object
-  msg.pos_measured.x = translational_estimator_results.position_measured.x();
-  msg.pos_measured.y = translational_estimator_results.position_measured.y();
-  msg.pos_measured.z = translational_estimator_results.position_measured.z();
+  tf::vectorEigenToMsg(translational_estimator_results.position_measured_, msg.pos_measured);
+
   // Writing the old estimates to the message object
-  msg.pos_old.x = translational_estimator_results.position_old_.x();
-  msg.pos_old.y = translational_estimator_results.position_old_.y();
-  msg.pos_old.z = translational_estimator_results.position_old_.z();
-  msg.vel_old.x = translational_estimator_results.velocity_old_.x();
-  msg.vel_old.y = translational_estimator_results.velocity_old_.y();
-  msg.vel_old.z = translational_estimator_results.velocity_old_.z();
+  tf::vectorEigenToMsg(translational_estimator_results.position_old_, msg.pos_old);
+  tf::vectorEigenToMsg(translational_estimator_results.velocity_old_, msg.vel_old);
+
   // Posteriori results
-  msg.pos_est.x = translational_estimator_results.position_estimate_.x();
-  msg.pos_est.y = translational_estimator_results.position_estimate_.y();
-  msg.pos_est.z = translational_estimator_results.position_estimate_.z();
-  msg.vel_est.x = translational_estimator_results.velocity_estimate_.x();
-  msg.vel_est.y = translational_estimator_results.velocity_estimate_.y();
-  msg.vel_est.z = translational_estimator_results.velocity_estimate_.z();
+  tf::vectorEigenToMsg(translational_estimator_results.position_estimate_, msg.pos_est);
+  tf::vectorEigenToMsg(translational_estimator_results.velocity_estimate_, msg.vel_est);
 
   // Writing the measurement to the message object
-  msg.quat_measured.w = rotational_estimator_results.orientation_measured_.w();
-  msg.quat_measured.x = rotational_estimator_results.orientation_measured_.x();
-  msg.quat_measured.y = rotational_estimator_results.orientation_measured_.y();
-  msg.quat_measured.z = rotational_estimator_results.orientation_measured_.z();
+  tf::quaternionEigenToMsg(rotational_estimator_results.orientation_measured_, msg.quat_measured);
+  tf::quaternionEigenToMsg(rotational_estimator_results.orientation_measured_corrected_, msg.quat_measured_corrected); 
+
   // Writing the old estimates to the message object
-  msg.quat_old.w = rotational_estimator_results.orientation_old_.w();
-  msg.quat_old.x = rotational_estimator_results.orientation_old_.x();
-  msg.quat_old.y = rotational_estimator_results.orientation_old_.y();
-  msg.quat_old.z = rotational_estimator_results.orientation_old_.z();
-  msg.omega_old.x = rotational_estimator_results.rate_old_.x();
-  msg.omega_old.y = rotational_estimator_results.rate_old_.y();
-  msg.omega_old.z = rotational_estimator_results.rate_old_.z();
+  tf::quaternionEigenToMsg(rotational_estimator_results.orientation_old_, msg.quat_old); 
+  tf::vectorEigenToMsg(rotational_estimator_results.rate_old_, msg.omega_old);
+
   // Posteriori results
-  msg.quat_est.w = rotational_estimator_results.orientation_estimate_.w();
-  msg.quat_est.x = rotational_estimator_results.orientation_estimate_.x();
-  msg.quat_est.y = rotational_estimator_results.orientation_estimate_.y();
-  msg.quat_est.z = rotational_estimator_results.orientation_estimate_.z();
-  msg.omega_est.x = rotational_estimator_results.rate_estimate_.x();
-  msg.omega_est.y = rotational_estimator_results.rate_estimate_.y();
-  msg.omega_est.z = rotational_estimator_results.rate_estimate_.z();
+  tf::quaternionEigenToMsg(rotational_estimator_results.orientation_estimate_, msg.quat_est);
+  tf::vectorEigenToMsg(rotational_estimator_results.rate_estimate_, msg.omega_est);
+
+  // Data to do with the measurement error
+  msg.outlier_flag.data = rotational_estimator_results.measurement_outlier_flag_;
+  msg.measurement_flip_flag.data = rotational_estimator_results.measurement_flip_flag_;
+  tf::quaternionEigenToMsg(rotational_estimator_results.q_Z_Z1_, msg.q_Z_Z1);
+  msg.q_Z_Z1_magnitude.data = rotational_estimator_results.q_Z_Z1_magnitude_; 
+  tf::quaternionEigenToMsg(rotational_estimator_results.q_Z_B_, msg.q_Z_B);
+  msg.q_Z_B_magnitude.data = rotational_estimator_results.q_Z_B_magnitude_;   
 
   // Publishing estimator message
   publisher_.publish(msg);

--- a/src/wrapper/vicon_odometry_estimator.cpp
+++ b/src/wrapper/vicon_odometry_estimator.cpp
@@ -60,6 +60,8 @@ void ViconOdometryEstimator::initializeParameters(ros::NodeHandle& nh)
               rotationalEstimatorParameters.outlier_threshold_degrees_);
   nh.getParam("rotational_estimator/maximum_outlier_count",
               rotationalEstimatorParameters.maximum_outlier_count_);
+  nh.getParam("rotational_estimator/output_minimal_quaternions",
+              rotationalEstimatorParameters.output_minimal_quaternions_);
 
   // Setting parameters in estimator
   vicon_estimator_.setParameters(translationalEstimatorParameters, rotationalEstimatorParameters);


### PR DESCRIPTION
Changes to make the estimator robust to:

- Flips between redundant quaternion representations of the measured orientation.
- Legitimate flips of the measured rotation (outliers)

Additional changes:

- Estimator parameter tuning for real world data
- Addition of the "EIGEN_MAKE_ALIGNED_OPERATOR_NEW" where it was missing.

Comments: There are a few improvement I think would still be nice:

- Given that the measurement flipping caused significant issues i think it makes sense to include a regression test to ensure that susceptibility to this effect is not reintroduced in future changes.
- It would be nice for this estimator, and for other places in our future infrastructure, to define a library for control/estimation on SO(3) derived manifolds. That way these issues don't crop up again and again.
- I think we can improve the way we're detecting outliers using the [mahalanobis distance](https://en.wikipedia.org/wiki/Mahalanobis_distance).