### PR TITLE
Feature/timestamp selection

### DIFF
--- a/launch/asl_optitrack.launch
+++ b/launch/asl_optitrack.launch
@@ -2,5 +2,6 @@
   <node name="starleth" type="ros_vrpn_client" pkg="ros_vrpn_client" output="screen">
     <param name="vrpn_server_ip" value="192.168.1.101" />
     <param name="vrpn_coordinate_system" value="optitrack" />
+    <param name="timestamping_system" value="tracker" />
   </node>
 </launch>

--- a/launch/asl_vicon.launch
+++ b/launch/asl_vicon.launch
@@ -3,7 +3,7 @@
   <node ns="$(arg object_name)" name="vrpn_client" type="ros_vrpn_client" pkg="ros_vrpn_client" output="screen">
     <param name="vrpn_server_ip" value="vicon" />
     <param name="vrpn_coordinate_system" value="vicon" />
-    <param name="timestamping_system" value="vicon" />
+    <param name="timestamping_system" value="tracker" />
     <param name="object_name" value="$(arg object_name)" />
     <param name="vicon_estimator/dt" value="0.01" />
     <param name="translational_estimator/kp" value="1.0" />

--- a/launch/asl_vicon.launch
+++ b/launch/asl_vicon.launch
@@ -3,6 +3,7 @@
   <node ns="$(arg object_name)" name="vrpn_client" type="ros_vrpn_client" pkg="ros_vrpn_client" output="screen">
     <param name="vrpn_server_ip" value="vicon" />
     <param name="vrpn_coordinate_system" value="vicon" />
+    <param name="timestamping_system" value="vicon" />
     <param name="object_name" value="$(arg object_name)" />
     <param name="vicon_estimator/dt" value="0.01" />
     <param name="translational_estimator/kp" value="1.0" />

--- a/src/ros_vrpn_client.cpp
+++ b/src/ros_vrpn_client.cpp
@@ -339,7 +339,7 @@ int main(int argc, char* argv[])
   private_nh.param<int>("vrpn_port", vrpn_port, 3883);
   private_nh.param<std::string>("vrpn_coordinate_system", coordinate_system_string, "vicon");
   private_nh.param<std::string>("object_name", object_name, "auk");
-  private_nh.param<std::string>("timestamping_system", timestamping_system_string, "blah");
+  private_nh.param<std::string>("timestamping_system", timestamping_system_string, "ros");
 
   // Debug output
   std::cout << "vrpn_server_ip:" << vrpn_server_ip << std::endl;
@@ -371,9 +371,6 @@ int main(int argc, char* argv[])
     ROS_FATAL("ROS param timestamping_system should be either 'vicon' or 'ros'!");
     return EXIT_FAILURE;
   }
-
-
-
 
   // Creating the estimator
   vicon_odometry_estimator = new vicon_estimator::ViconOdometryEstimator(private_nh);

--- a/src/ros_vrpn_client.cpp
+++ b/src/ros_vrpn_client.cpp
@@ -78,7 +78,7 @@ enum CoordinateSystem
 // Available timestamping options.
 enum TimestampingSystem
 {
-  kViconStamp,
+  kTrackerStamp,
   kRosStamp
 } timestamping_system;
 
@@ -207,20 +207,20 @@ void inline correctForCoordinateSystem(const Eigen::Quaterniond& orientation_in,
 void inline getTimeStamp(const ros::Time& vicon_stamp, ros::Time* timestamp)
 {
   // Stamping message depending on selected stamping source
-  // vicon: Use stamp attached to the vrpn_client callback comming from the 
-  //        vicon system. Not that this timestamp may not be synced to the
-  //        ros time. Additionally the timestamping contains some delay which
-  //        is a fixed number of hours due (possibly) to a timezone difference
-  //        in the tracker software. These delay hours are removed in this
-  //        function.
-  // ros:   Stamp the message on arrival with the current ros time.
+  // tracker: Use stamp attached to the vrpn_client callback comming from the 
+  //          tracker system. Not that this timestamp may not be synced to the
+  //          ros time. Additionally the timestamping contains some delay which
+  //          is a fixed number of hours due (possibly) to a timezone difference
+  //          in the tracker software. These delay hours are removed in this
+  //          function.
+  // ros:     Stamp the message on arrival with the current ros time.
   switch (timestamping_system)
   {
-    case kViconStamp:
+    case kTrackerStamp:
     {
       // Retreiving current ROS Time
       ros::Time ros_stamp = ros::Time::now();
-      // Calculating the difference between the vicon attached timestamp and the current ROS time.
+      // Calculating the difference between the tracker attached timestamp and the current ROS time.
       ros::Duration time_diff = vicon_stamp - ros_stamp;
       // Working out the hours difference in hours and then rounding to the closest hour
       const double kHoursToSec = 3600;
@@ -339,7 +339,7 @@ int main(int argc, char* argv[])
   private_nh.param<int>("vrpn_port", vrpn_port, 3883);
   private_nh.param<std::string>("vrpn_coordinate_system", coordinate_system_string, "vicon");
   private_nh.param<std::string>("object_name", object_name, "auk");
-  private_nh.param<std::string>("timestamping_system", timestamping_system_string, "ros");
+  private_nh.param<std::string>("timestamping_system", timestamping_system_string, "tracker");
 
   // Debug output
   std::cout << "vrpn_server_ip:" << vrpn_server_ip << std::endl;
@@ -361,14 +361,14 @@ int main(int argc, char* argv[])
   }
 
   // Setting the time stamping option based on the ros param
-  if (timestamping_system_string == "vicon") {
-    timestamping_system = TimestampingSystem::kViconStamp;
+  if (timestamping_system_string == "tracker") {
+    timestamping_system = TimestampingSystem::kTrackerStamp;
   }
   else if (timestamping_system_string == "ros") {
     timestamping_system = TimestampingSystem::kRosStamp;
   }
   else {
-    ROS_FATAL("ROS param timestamping_system should be either 'vicon' or 'ros'!");
+    ROS_FATAL("ROS param timestamping_system should be either 'tracker' or 'ros'!");
     return EXIT_FAILURE;
   }
 

--- a/src/ros_vrpn_client.cpp
+++ b/src/ros_vrpn_client.cpp
@@ -210,24 +210,36 @@ void inline getTimeStamp(const ros::Time& vicon_stamp, ros::Time* timestamp)
   // vicon: Use stamp attached to the vrpn_client callback comming from the 
   //        vicon system. Not that this timestamp may not be synced to the
   //        ros time. Additionally the timestamping contains some delay which
-  //        is a fixed number of hours. This is removed below.
-  //
+  //        is a fixed number of hours due (possibly) to a timezone difference
+  //        in the tracker software. These delay hours are removed in this
+  //        function.
   // ros:   Stamp the message on arrival with the current ros time.
   switch (timestamping_system)
   {
     case kViconStamp:
     {
-      // DEBUG(millanea): Trying to get a clearer picture of what the fuck is 
-      //                  going on.
-      std::cout << "vicon_stamp: " << vicon_stamp << std::endl;
+      // Retreiving current ROS Time
       ros::Time ros_stamp = ros::Time::now();
-      std::cout << "ros_stamp: " << ros_stamp << std::endl;
-      // Output
-      *timestamp = vicon_stamp;
+      // Calculating the difference between the vicon attached timestamp and the current ROS time.
+      ros::Duration time_diff = vicon_stamp - ros_stamp;
+      // Working out the hours difference in hours and then rounding to the closest hour
+      const double kHoursToSec = 3600;
+      double time_diff_h = time_diff.toSec() / kHoursToSec;
+      double time_diff_h_round = std::round(time_diff_h);
+      // Correcting the time stamp by the hours difference and reassembling timestamp
+      double time_correction_s = time_diff_h_round * kHoursToSec;
+      ros::Time vicon_stamp_corrected(vicon_stamp.sec - time_correction_s, vicon_stamp.nsec);
+      // Attaching the corrected timestamp
+      *timestamp = vicon_stamp_corrected;
+      // Outputting the time delay to the ROS console if bigger than 0.1s
+      ros::Duration time_diff_corrected = ros_stamp - vicon_stamp_corrected;
+      if (std::abs(time_diff_corrected.toSec()) > 0.1) {
+        ROS_WARN_STREAM_THROTTLE(1, "Time delay: " << time_diff_corrected.toSec());
+      }
     }
     case kRosStamp:
     {
-      // Output
+      // Just attach the current ROS timestamp
       *timestamp = ros::Time::now();
     }
   }
@@ -263,25 +275,11 @@ void VRPN_CALLBACK track_target(void *, const vrpn_TRACKERCB tracker)
   }
   prev_tracker = tracker;
 
-  // Somehow the vrpn msgs are in a different time zone.
+  // Timestamping the incomming message
   const int kMicroSecToNanoSec = 1000;
-  const double kHoursToSec = 3600;
-  ros::Time timestamp_local = ros::Time::now();
-  int timediff_sec = std::round(double(timestamp_local.sec - tracker.msg_time.tv_sec) / kHoursToSec) * kHoursToSec;
-
-  int timestamp_nsec = tracker.msg_time.tv_usec * kMicroSecToNanoSec;
-  ros::Time timestamp = ros::Time(tracker.msg_time.tv_sec + timediff_sec, timestamp_nsec);
-
-  ros::Duration time_diff = ros::Time::now() - timestamp;
-  if (std::abs(time_diff.toSec()) > 0.1) {
-    ROS_WARN_STREAM_THROTTLE(1, "Time delay: " << time_diff.toSec());
-  }
-
-  // TODO(millanea): UP TO HERE.
-  //                 Try to sort out the absolute hackery above. Will be useful for vicon to csv anyway.
-  ros::Time tracker_time(tracker.msg_time.tv_sec, tracker.msg_time.tv_usec*kMicroSecToNanoSec);
-  ros::Time timestamp2;
-  getTimeStamp(tracker_time, &timestamp2);
+  ros::Time tracker_timestamp(tracker.msg_time.tv_sec, tracker.msg_time.tv_usec*kMicroSecToNanoSec);
+  ros::Time timestamp;
+  getTimeStamp(tracker_timestamp, &timestamp);
 
   // Updating the estimates with the new measurements.
   vicon_odometry_estimator->updateEstimate(position_measured_W, orientation_measured_B_W);
@@ -341,7 +339,7 @@ int main(int argc, char* argv[])
   private_nh.param<int>("vrpn_port", vrpn_port, 3883);
   private_nh.param<std::string>("vrpn_coordinate_system", coordinate_system_string, "vicon");
   private_nh.param<std::string>("object_name", object_name, "auk");
-  private_nh.param<std::string>("timestamping_system", timestamping_system_string, "auk");
+  private_nh.param<std::string>("timestamping_system", timestamping_system_string, "blah");
 
   // Debug output
   std::cout << "vrpn_server_ip:" << vrpn_server_ip << std::endl;


### PR DESCRIPTION
At Mina's request I have added the option to timestamp vrpn messages with ros time. Additionally I have attempted make more clear the hackery we do to correct for (suspected) time zone differences between local and the vicon tracker machines.