### PR TITLE
Noisy vicon

### DIFF
--- a/cfg/noisy_vicon.yaml
+++ b/cfg/noisy_vicon.yaml
@@ -1,7 +1,0 @@
-# Noise parameters for vicon spoofer
-
-# Maximum noise radius (polar coordinates)
-max_noise_radius: 0.1   # [m]
-
-# Timeout between noise sampling updates
-publish_timeout: 0.2    # [s]

--- a/cfg/noisy_vicon.yaml
+++ b/cfg/noisy_vicon.yaml
@@ -1,7 +1,7 @@
 # Noise parameters for vicon spoofer
 
 # Maximum noise radius (polar coordinates)
-max_noise_radius = 0.1   # [m]
+max_noise_radius: 0.1   # [m]
 
 # Timeout between noise sampling updates
-publish_timeout = 0.2    # [s]
+publish_timeout: 0.2    # [s]

--- a/src/noisy_vicon.py
+++ b/src/noisy_vicon.py
@@ -120,7 +120,7 @@ class NoisyVicon:
 
     if (self.publish_pose):
         self.pub_disturbed_pose.publish(self.pwc)
-    self.pub_point.publish(self.point)
+    self.point_pub.publish(self.point)
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
"noisy_vicon" is a cleaned-up version of "gps_spoofer" from geodetic_utils, which allows adding noise on vicon measurements and publishing a spoofed GPS message. Compared to the previous version, the code has been tidied up by using new params, removing old comments, fixing formatting, etc. The MAV vicon_spoofed files have been altered to reflect this change and the launch files have been tested in Vicon.

@enricgalceran @raghavkhanna 