### PR TITLE
Fixing rotation of velocity to body frame.

### DIFF
--- a/src/ros_vrpn_client.cpp
+++ b/src/ros_vrpn_client.cpp
@@ -297,7 +297,7 @@ void VRPN_CALLBACK track_target(void *, const vrpn_TRACKERCB tracker)
   vicon_odometry_estimator->publishIntermediateResults(timestamp);
 
   // Rotating the estimated global frame velocity into the body frame.
-  Eigen::Vector3d velocity_estimate_B = orientation_estimate_B_W.toRotationMatrix() * velocity_estimate_W;
+  Eigen::Vector3d velocity_estimate_B = orientation_estimate_B_W.toRotationMatrix().transpose() * velocity_estimate_W;
 
   // Populate the raw measured transform message. Published in main loop.
   target_state->measured_transform.header.stamp = timestamp;


### PR DESCRIPTION
Correcting rotation of the estimated velocity to the body frame. Problem noticed by challenger and raised in an issue found here:

https://github.com/ethz-asl/euroc_stage_2/issues/44

This also revealed that the euroc stage 2 coordinate conventions page indicated we were using passive quaternions. I have now replaced this page with the mav_tools conventions page.