### PR TITLE
Feature/cuckoo

### DIFF
--- a/launch/asl_vicon.launch
+++ b/launch/asl_vicon.launch
@@ -1,9 +1,11 @@
 <launch>
   <arg name="object_name" default="bluebird" />
+  <arg name="timestamping_system" default="ros" />
+
   <node ns="$(arg object_name)" name="vrpn_client" type="ros_vrpn_client" pkg="ros_vrpn_client" output="screen">
     <param name="vrpn_server_ip" value="vicon" />
     <param name="vrpn_coordinate_system" value="vicon" />
-    <param name="timestamping_system" value="ros" />
+    <param name="timestamping_system" value="$(arg timestamping_system)" />
     <param name="object_name" value="$(arg object_name)" />
     <param name="verbose" value="true" />
     <param name="translational_estimator/kp" value="0.5" />

--- a/package.xml
+++ b/package.xml
@@ -30,4 +30,6 @@
   <depend>eigen_conversions</depend>
   <depend>glog_catkin</depend>
 
+  <depend>cuckoo_time_translator</depend>
+
 </package>


### PR DESCRIPTION
We notices some time delay between the IMU angular velocity on our robot and the angular velocity published by Vicon.

In order to improve time stamping we tried to deploy [cuckoo time translator](https://github.com/ethz-asl/cuckoo_time_translator). Still some delay in the range of 50 to 60ms remains. 

Time stamping: tracker, about 200ms delay
![tracker_200ms](https://user-images.githubusercontent.com/11293852/103528978-2eef8c80-4e85-11eb-8d9e-97faeab0718d.png)

Time stamping: ros, about 75ms delay
![ros_75ms](https://user-images.githubusercontent.com/11293852/103528989-3151e680-4e85-11eb-9bbe-5210d3915a4d.png)

Time stamping: cuckoo, about 60ms delay
![cuckoo_60ms](https://user-images.githubusercontent.com/11293852/103528998-33b44080-4e85-11eb-8d87-09ecff51ac77.png)
