### PR TITLE
fix: Retrieving ros time to work with newer ROS 2 versions

### DIFF
--- a/src/ros_vrpn_client.cpp
+++ b/src/ros_vrpn_client.cpp
@@ -289,7 +289,7 @@ void inline getTimeStamp(
   switch (nh->timestamping_system) {
     case kTrackerStamp: {
       // Retreiving current ROS Time
-      rclcpp::Time ros_stamp = nh->get_clock()->now();
+      rclcpp::Time ros_stamp = nh->now();
       // Calculating the difference between the tracker attached timestamp and
       // the current ROS time.
       rclcpp::Duration time_diff = vicon_stamp - ros_stamp;
@@ -310,14 +310,14 @@ void inline getTimeStamp(
         rclcpp::Duration time_diff_corrected = ros_stamp - vicon_stamp_corrected;
         static const int kMaxMessagePeriod = 2000;
         RCLCPP_WARN_STREAM_THROTTLE(
-          nh->get_logger(), *nh->get_clock(), kMaxMessagePeriod,
+          nh->get_logger(), *nh, kMaxMessagePeriod,
           "Time delay: " << time_diff_corrected.seconds());
       }
       break;
     }
     case kRosStamp: {
       // Just attach the current ROS timestamp
-      *timestamp = nh->get_clock()->now();
+      *timestamp = nh->now();
       break;
     }
   }


### PR DESCRIPTION
Currently when building with ROS 2 Humble the following error is encountered: 
```
error: passing ‘std::__shared_ptr_access<const rclcpp::Clock, __gnu_cxx::_S_atomic, false, false>::element_type’ {aka ‘const rclcpp::Clock’} as ‘this’ argument discards qualifiers [-fpermissive]
  320 |       *timestamp = nh->get_clock()->now();
```

This PR fixes the above error. The code was tested on two Ubuntu 22.04 devices running ROS 2 Humble. I didn't check if this breaks compatibility with older ROS 2 versions but I would find it reasonable if the ROS 2 branch works for the current LTS version.



